### PR TITLE
feat(api): endpoint billable par employé + CORS + auth par clé

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -1,9 +1,45 @@
-from fastapi import FastAPI, Query, HTTPException
+import os
+from typing import Callable, List, Optional
+
+from fastapi import Depends, FastAPI, Header, HTTPException, Query
+from fastapi.middleware.cors import CORSMiddleware
+
 from reports.tempo_reports import TempoReport
 from reports.jira_reports import JiraReports
 from datetime import datetime, timedelta
 
 app = FastAPI(title="Jira Tempo Reports API")
+
+# ---------------------------------------------------------------------------
+# CORS — restreint aux origines autorisées (config via ALLOWED_ORIGINS).
+# Par défaut : dev local. En production, définir ALLOWED_ORIGINS avec le
+# domaine de l'app (ex. "https://mon-app.vercel.app").
+# ---------------------------------------------------------------------------
+ALLOWED_ORIGINS = [
+    o.strip()
+    for o in os.getenv(
+        "ALLOWED_ORIGINS", "http://localhost:5173,http://localhost:3000"
+    ).split(",")
+    if o.strip()
+]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=ALLOWED_ORIGINS,
+    allow_methods=["GET"],
+    allow_headers=["*"],
+)
+
+# ---------------------------------------------------------------------------
+# Auth — clé API optionnelle. Si REPORTS_API_KEY est définie côté serveur,
+# chaque requête doit fournir l'en-tête "X-API-Key" correspondant.
+# ---------------------------------------------------------------------------
+API_KEY = os.getenv("REPORTS_API_KEY")
+
+
+def require_api_key(x_api_key: Optional[str] = Header(default=None)):
+    if API_KEY and x_api_key != API_KEY:
+        raise HTTPException(status_code=401, detail="Invalid or missing API key")
 
 
 def f2(value):
@@ -11,24 +47,27 @@ def f2(value):
     return f"{value:.2f}"
 
 
-def compute_billable_hours(account_key: str, start_date: str, end_date: str) -> dict:
-    tempo = TempoReport()
-    jira = JiraReports()
+def _compute_billable_from_worklogs(
+    worklogs: List[dict],
+    fetch_historical: Callable[[str], List[dict]],
+    start_date: str,
+    tempo: TempoReport,
+    jira: JiraReports,
+) -> Optional[dict]:
+    """Cœur du calcul billable/leaked par ticket, indépendant de la source
+    des worklogs (compte Tempo ou utilisateur).
 
-    worklogs = tempo.fetch_worklogs_by_account(account_key, start_date, end_date)
+    - worklogs : worklogs de la période à analyser.
+    - fetch_historical(day_before) : renvoie les worklogs *avant* la période,
+      pour calculer la fuite (leaked) cumulée correctement.
+
+    Retourne None si aucun worklog sur la période (le caller renvoie un
+    rapport vide).
+    """
     if not worklogs:
-        return {
-            "account_key": account_key,
-            "start_date": start_date,
-            "end_date": end_date,
-            "total_logged": f2(0),
-            "total_billable": f2(0),
-            "total_non_billable": f2(0),
-            "billable_ratio": f2(0),
-            "issues": [],
-        }
+        return None
 
-    # Aggregate logged time per issue for the period
+    # Agrège le temps loggé par ticket sur la période.
     time_by_issue = {}
     for log in worklogs:
         issue_id = str(log["issue"]["id"])
@@ -40,10 +79,10 @@ def compute_billable_hours(account_key: str, start_date: str, end_date: str) -> 
                 time_by_issue[issue_key] = {"logged": 0}
             time_by_issue[issue_key]["logged"] += log["timeSpentSeconds"] / 3600
 
-    # Fetch historical worklogs before the period
+    # Worklogs historiques (avant la période) pour la fuite cumulée.
     start_dt = datetime.strptime(start_date, "%Y-%m-%d")
     day_before = (start_dt - timedelta(days=1)).strftime("%Y-%m-%d")
-    historical_worklogs = tempo.fetch_worklogs_by_account(account_key, "2015-01-01", day_before)
+    historical_worklogs = fetch_historical(day_before)
     timespent_before = {}
     for log in historical_worklogs:
         issue_id = str(log["issue"]["id"])
@@ -51,9 +90,11 @@ def compute_billable_hours(account_key: str, start_date: str, end_date: str) -> 
             tempo._issue_key_cache[issue_id] = jira.get_issue_key_from_id(issue_id)
         issue_key = tempo._issue_key_cache[issue_id]
         if issue_key:
-            timespent_before[issue_key] = timespent_before.get(issue_key, 0) + log["timeSpentSeconds"] / 3600
+            timespent_before[issue_key] = (
+                timespent_before.get(issue_key, 0) + log["timeSpentSeconds"] / 3600
+            )
 
-    # Fetch Jira estimates and compute leaked/billable per issue
+    # Estimations Jira + fuite/billable par ticket.
     for issue_key in time_by_issue:
         try:
             response = jira._get_issue_fields(issue_key)
@@ -88,9 +129,6 @@ def compute_billable_hours(account_key: str, start_date: str, end_date: str) -> 
     ]
 
     return {
-        "account_key": account_key,
-        "start_date": start_date,
-        "end_date": end_date,
         "total_logged": f2(total_logged),
         "total_billable": f2(total_billable),
         "total_non_billable": f2(total_leaked),
@@ -99,12 +137,55 @@ def compute_billable_hours(account_key: str, start_date: str, end_date: str) -> 
     }
 
 
-@app.get("/api/billable-hours")
-def get_billable_hours(
-    account_key: str = Query(..., description="Tempo account key"),
-    start_date: str = Query(..., description="Start date (YYYY-MM-DD)"),
-    end_date: str = Query(..., description="End date (YYYY-MM-DD)"),
-):
+def _empty_report() -> dict:
+    return {
+        "total_logged": f2(0),
+        "total_billable": f2(0),
+        "total_non_billable": f2(0),
+        "billable_ratio": f2(0),
+        "issues": [],
+    }
+
+
+def compute_billable_hours(account_key: str, start_date: str, end_date: str) -> dict:
+    """Rapport billable par **compte** Tempo (client/projet)."""
+    tempo = TempoReport()
+    jira = JiraReports()
+
+    worklogs = tempo.fetch_worklogs_by_account(account_key, start_date, end_date)
+    result = _compute_billable_from_worklogs(
+        worklogs,
+        lambda day_before: tempo.fetch_worklogs_by_account(account_key, "2015-01-01", day_before),
+        start_date,
+        tempo,
+        jira,
+    )
+    base = {"account_key": account_key, "start_date": start_date, "end_date": end_date}
+    return {**base, **(result or _empty_report())}
+
+
+def compute_employee_billable_hours(account_id: str, start_date: str, end_date: str) -> dict:
+    """Rapport billable par **employé** (Jira/Tempo accountId).
+
+    Même calcul que par compte, mais les worklogs sont filtrés sur une seule
+    personne via l'endpoint utilisateur de Tempo.
+    """
+    tempo = TempoReport()
+    jira = JiraReports()
+
+    worklogs = tempo.fetch_worklogs_by_user(account_id, start_date, end_date)
+    result = _compute_billable_from_worklogs(
+        worklogs,
+        lambda day_before: tempo.fetch_worklogs_by_user(account_id, "2015-01-01", day_before),
+        start_date,
+        tempo,
+        jira,
+    )
+    base = {"account_id": account_id, "start_date": start_date, "end_date": end_date}
+    return {**base, **(result or _empty_report())}
+
+
+def _validate_dates(start_date: str, end_date: str):
     try:
         datetime.strptime(start_date, "%Y-%m-%d")
         datetime.strptime(end_date, "%Y-%m-%d")
@@ -114,4 +195,22 @@ def get_billable_hours(
     if start_date > end_date:
         raise HTTPException(status_code=400, detail="start_date must be before end_date")
 
+
+@app.get("/api/billable-hours", dependencies=[Depends(require_api_key)])
+def get_billable_hours(
+    account_key: str = Query(..., description="Tempo account key"),
+    start_date: str = Query(..., description="Start date (YYYY-MM-DD)"),
+    end_date: str = Query(..., description="End date (YYYY-MM-DD)"),
+):
+    _validate_dates(start_date, end_date)
     return compute_billable_hours(account_key, start_date, end_date)
+
+
+@app.get("/api/employee-billable-hours", dependencies=[Depends(require_api_key)])
+def get_employee_billable_hours(
+    account_id: str = Query(..., description="Jira/Tempo user accountId"),
+    start_date: str = Query(..., description="Start date (YYYY-MM-DD)"),
+    end_date: str = Query(..., description="End date (YYYY-MM-DD)"),
+):
+    _validate_dates(start_date, end_date)
+    return compute_employee_billable_hours(account_id, start_date, end_date)

--- a/app/reports/tempo_reports.py
+++ b/app/reports/tempo_reports.py
@@ -72,6 +72,33 @@ class TempoReport:
 
         return all_worklogs
 
+    def fetch_worklogs_by_user(self, account_id, start_date, end_date):
+        """Fetch worklogs for a specific user (Jira accountId) using the dedicated endpoint."""
+        url = f"https://api.tempo.io/4/worklogs/user/{account_id}"
+        all_worklogs = []
+        page_index = 0
+        page_size = 50
+
+        while True:
+            params = {
+                'from': start_date,
+                'to': end_date,
+                'limit': page_size,
+                'offset': page_index * page_size,
+            }
+            response = tempo_request("GET", url, params=params)
+            response.raise_for_status()
+            data = response.json()
+            worklogs = data.get('results', [])
+            if not worklogs:
+                break
+            all_worklogs.extend(worklogs)
+            if not data.get('metadata', {}).get('next'):
+                break
+            page_index += 1
+
+        return all_worklogs
+
     def _get_cached_worklogs(self, start_date: str, end_date: str) -> List[Dict]:
         cache_key = f"{start_date}_{end_date}"
         if cache_key not in self._worklog_cache:


### PR DESCRIPTION
## Contexte
Le tableau de bord de rendement (repo séparé) doit générer ses rapports **par employé** à partir des données live Jira/Tempo, au lieu d'un import CSV. L'endpoint existant `/api/billable-hours` agrège **par compte Tempo (client/projet)** — il ne convient pas pour un rapport individuel.

## Ce que fait cette PR
- **Nouvel endpoint** `GET /api/employee-billable-hours?account_id=&start_date=&end_date=` : mêmes métriques par ticket (`estimated`, `timespent_total`, `logged`, `billable`, `leaked` + totaux) mais pour **une seule personne**, via son `accountId` Jira/Tempo.
- **`TempoReport.fetch_worklogs_by_user`** : worklogs filtrés par utilisateur (`/worklogs/user/{accountId}`), calqué sur `fetch_worklogs_by_account`.
- **Refactor sans changement de comportement** : le cœur du calcul est extrait dans `_compute_billable_from_worklogs`, partagé par les deux endpoints. La sortie de `/api/billable-hours` est inchangée.
- **CORS** restreint via `ALLOWED_ORIGINS` (défaut : `localhost:5173,localhost:3000`).
- **Auth par clé optionnelle** : si `REPORTS_API_KEY` est définie, l'en-tête `X-API-Key` est exigé sur les deux endpoints (rétrocompatible si non définie).

## ⚠️ À valider avant merge
- [x] **Endpoint Tempo utilisateur** : confirmer que `/worklogs/4/worklogs/user/{accountId}` est bien le bon chemin et accepte `from`/`to` comme `/worklogs/account/{key}` (non testé en live ici, faute d'accès aux secrets Tempo).
- [x] Définir `REPORTS_API_KEY` **et** `ALLOWED_ORIGINS` (domaine de l'app) dans l'environnement de prod — sinon l'endpoint reste public (comportement actuel).
- [x] Vérifier la charge du fetch historique (`from=2015-01-01`) par utilisateur.

## Nouvelles variables d'environnement
| Variable | Rôle | Défaut |
|---|---|---|
| `REPORTS_API_KEY` | Exige `X-API-Key` si définie | (non défini → public) |
| `ALLOWED_ORIGINS` | Origines CORS autorisées (CSV) | `http://localhost:5173,http://localhost:3000` |