### PR TITLE
perf(api): billable via requête JQL batch (fix 504)

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -57,10 +57,11 @@ def _compute_billable_from_worklogs(
 
     - worklogs : worklogs de la période à analyser.
 
-    Le temps cumulé (timespent_total) et l'estimation sont lus directement
-    depuis Jira (un seul appel par ticket, déjà nécessaire pour l'estimation).
+    Le temps cumulé (timespent_total) et l'estimation sont lus depuis Jira en
+    UNE requête JQL batch (`id in (...)`) au lieu de 2 appels séquentiels par
+    ticket — c'était la cause des timeouts 504 sur les employés à gros volume.
     Le temps AVANT la période est dérivé (cumul − loggé sur la période), ce qui
-    évite de balayer tout l'historique Tempo depuis 2015 (source des timeouts).
+    évite aussi de balayer tout l'historique Tempo depuis 2015.
 
     Retourne None si aucun worklog sur la période (le caller renvoie un
     rapport vide).
@@ -68,28 +69,26 @@ def _compute_billable_from_worklogs(
     if not worklogs:
         return None
 
-    # Agrège le temps loggé par ticket sur la période.
-    time_by_issue = {}
+    # Agrège le temps loggé par issue_id sur la période.
+    logged_by_id: dict = {}
     for log in worklogs:
         issue_id = str(log["issue"]["id"])
-        if issue_id not in tempo._issue_key_cache:
-            tempo._issue_key_cache[issue_id] = jira.get_issue_key_from_id(issue_id)
-        issue_key = tempo._issue_key_cache[issue_id]
-        if issue_key:
-            if issue_key not in time_by_issue:
-                time_by_issue[issue_key] = {"logged": 0}
-            time_by_issue[issue_key]["logged"] += log["timeSpentSeconds"] / 3600
+        logged_by_id[issue_id] = logged_by_id.get(issue_id, 0) + log["timeSpentSeconds"] / 3600
 
-    # Estimation + temps cumulé lus depuis Jira, fuite/billable par ticket.
-    for issue_key in time_by_issue:
-        try:
-            fields = jira._get_issue_fields(issue_key)
-        except Exception:
-            fields = None
-        estimated = (fields.get("timeoriginalestimate") or 0) / 3600 if fields else 0
-        timespent_total = (fields.get("timespent") or 0) / 3600 if fields else 0
+    # Batch : clé + estimation + cumul pour tous les billets d'un coup.
+    meta = jira.fetch_issues_by_ids(list(logged_by_id.keys()))
 
-        logged = time_by_issue[issue_key]["logged"]
+    # Estimation + temps cumulé, fuite/billable par ticket.
+    time_by_issue = {}
+    for issue_id, logged in logged_by_id.items():
+        m = meta.get(issue_id)
+        # Billet non résolu (supprimé / hors permissions) → ignoré, comme avant.
+        if not m or not m.get("key"):
+            continue
+        issue_key = m["key"]
+        estimated = m["estimated"]
+        timespent_total = m["timespent"]
+
         # Le cumul Jira doit au moins couvrir le temps loggé sur la période
         # (garde-fou contre un décalage de synchro Tempo -> Jira).
         if timespent_total < logged:
@@ -98,10 +97,13 @@ def _compute_billable_from_worklogs(
         leaked_avant = max(0, before - estimated)
         leaked_fin = max(0, timespent_total - estimated)
         leaked = leaked_fin - leaked_avant
-        time_by_issue[issue_key]["estimated"] = estimated
-        time_by_issue[issue_key]["timespent_total"] = timespent_total
-        time_by_issue[issue_key]["leaked"] = leaked
-        time_by_issue[issue_key]["billable"] = logged - leaked
+        time_by_issue[issue_key] = {
+            "logged": logged,
+            "estimated": estimated,
+            "timespent_total": timespent_total,
+            "leaked": leaked,
+            "billable": logged - leaked,
+        }
 
     total_logged = sum(v["logged"] for v in time_by_issue.values())
     total_leaked = sum(v["leaked"] for v in time_by_issue.values())

--- a/app/reports/jira_reports.py
+++ b/app/reports/jira_reports.py
@@ -171,3 +171,45 @@ class JiraReports:
                 break
 
         return issues
+
+    def fetch_issues_by_ids(self, issue_ids: List[str]) -> dict:
+        """Batch : {issue_id: {key, estimated (h), timespent (h)}} en une (ou
+        quelques) requête(s) JQL `id in (...)`.
+
+        Remplace les appels séquentiels get_issue_key_from_id + _get_issue_fields
+        (2 par billet) qui causaient des timeouts. Les IDs sont découpés en lots
+        (limite de longueur de la clause JQL) et chaque lot est paginé.
+        """
+        result: dict = {}
+        ids = [str(i) for i in issue_ids if i]
+        CHUNK = 100
+        for start in range(0, len(ids), CHUNK):
+            chunk = ids[start:start + CHUNK]
+            jql = f"id in ({','.join(chunk)})"
+            next_token = None
+            while True:
+                params = {
+                    'jql': jql,
+                    'fields': 'timeoriginalestimate,timespent',
+                    'maxResults': 100,
+                }
+                if next_token:
+                    params['nextPageToken'] = next_token
+
+                response = JiraApi.search(params)
+                response.raise_for_status()
+                data = response.json()
+
+                for issue in data.get('issues', []):
+                    f = issue.get('fields', {}) or {}
+                    result[str(issue.get('id'))] = {
+                        'key': issue.get('key'),
+                        'estimated': (f.get('timeoriginalestimate') or 0) / 3600,
+                        'timespent': (f.get('timespent') or 0) / 3600,
+                    }
+
+                next_token = data.get('nextPageToken')
+                if data.get('isLast', True) or not next_token:
+                    break
+
+        return result


### PR DESCRIPTION
## Problème
L'endpoint `billable-hours` / `employee-billable-hours` faisait **2 appels Jira séquentiels par billet** (`get_issue_key_from_id` + `_get_issue_fields`) → 25-31 s pour les employés à gros volume (ex. Nancy, 35 billets) → **504** au timeout de l'Edge Vercel.

## Fix
`JiraReports.fetch_issues_by_ids(issue_ids)` : résout **clé + estimation + cumul** pour tous les billets en **une requête JQL `id in (...)`** (lots de 100, paginée). `_compute_billable_from_worklogs` agrège désormais par `issue_id` puis mappe via ce batch.

- Math fuite/billable **inchangée** → parité de sortie préservée (à vérifier post-déploiement).
- Billets non résolus (supprimés/permissions) ignorés, comme avant.

## Vérifs
- `py_compile` OK.
- Parité billable Éric/Nancy à comparer après déploiement VPS (baseline capturé).

🤖 Generated with [Claude Code](https://claude.com/claude-code)